### PR TITLE
Trim unusable characters from status response

### DIFF
--- a/wsutil/wsutil.go
+++ b/wsutil/wsutil.go
@@ -147,6 +147,7 @@ func ActiveDevices(connection httputil.RingWSConnection) (*RingDeviceInfo, error
 	runes := []rune(wssResponse)
 	responseBody := string(runes[13 : len(wssResponse)-1])
 	//log.Printf("Response: %s\n\nJSON: %s", wssResponse, responseBody)
+	responseBody = responseBody[:strings.LastIndex(responseBody, "}") + 1]
 	log.Printf("Response: %s", responseBody)
 	err = json.Unmarshal([]byte(responseBody), &ringDeviceInfo)
 	if err != nil {


### PR DESCRIPTION
Extra characters at the end of the Get Status response were breaking the json unmarshall. This gets rid of all characters after the last close bracket in the response. I've verified that this fixes my problem getting status from Ring.