### PR TITLE
fixing runtime error: index out of range [0]

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func getAccessToken(apiRequest public.Request) (string, string, error) {
 }
 
 func getLocation(apiRequest public.Request, accessToken string) (httputil.UserLocation, error) {
-	location, err := httputil.LocationRequest("https://app.ring.com/rhq/v1/devices/v1/locations", accessToken)
+	location, err := httputil.LocationRequest("https://app.ring.com/devices/v1/locations", accessToken)
 	if err != nil {
 		return httputil.UserLocation{}, err
 	}


### PR DESCRIPTION
fixing

runtime error: index out of range [0] with length 0: boundsError
[
{
    "path": "github.com/aws/aws-lambda-go@v1.8.1/lambda/function.go",
    "line": 27,
    "label": "(*Function).Invoke.func1"
}
,
{
    "path": "runtime/panic.go",
    "line": 679,
    "label": "gopanic"
}
,
{
    "path": "runtime/panic.go",
    "line": 75,
    "label": "goPanicIndex"
}
,
{
    "path": "work/smartthings-ringalarmv2/smartthings-ringalarmv2/httputil/httputil.go",
    "line": 278,
    "label": "LocationRequest"
}



after digging and looking at other ring projects 
https://github.com/dgreif/ring/blob/08c8e1fa62e44c31405336f860f959b3628ebded/api/rest-client.ts#L28

the location url needs to be 
https://api.ring.com/devices/v1/locations

i even tested this locally using postman