### PR TITLE
Updated API url for devices call to point to correct dns name

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func getAccessToken(apiRequest public.Request) (string, string, error) {
 }
 
 func getLocation(apiRequest public.Request, accessToken string) (httputil.UserLocation, error) {
-	location, err := httputil.LocationRequest("https://app.ring.com/devices/v1/locations", accessToken)
+	location, err := httputil.LocationRequest("https://api.ring.com/devices/v1/locations", accessToken)
 	if err != nil {
 		return httputil.UserLocation{}, err
 	}


### PR DESCRIPTION
Addresses #60. The error appears to be that the `Locations` API call was using `app.ring.com` instead of `api.ring.com` as seen in https://github.com/dgreif/ring. I can only suspect that ring used to have everything go to `app.`, then introduced the split, and at some point sunset support for that API call on the `app` domain. Regardless, this change has revived the integration for me.